### PR TITLE
fix(k9s): add override=true to all plugins to prevent hotkey conflicts

### DIFF
--- a/k9s.sh
+++ b/k9s.sh
@@ -87,6 +87,10 @@ for PLUGIN in "${K9S_PLUGINS[@]}"; do
     --inplace "$K9S_CONFIG/plugins.yaml" "$PLUGIN"
 done
 
+# Add override: true to all plugins to prevent "duplicate plugin key found" errors
+# with built-in k9s shortcuts. See: https://github.com/derailed/k9s/issues/3886
+yq eval '.plugins[].override = true' --inplace "$K9S_CONFIG/plugins.yaml"
+
 rm -rf k9s
 rm -rf k8s-tooling
 


### PR DESCRIPTION
## Problem

When installing k9s with these plugins, hotkeys that conflict with built-in k9s shortcuts (like `Shift-S`) produce a misleading "duplicate plugin key found" error.

## Solution

Add `override: true` to all plugins during installation via a `yq` post-processing step. This suppresses the error without modifying the source plugin YAML files.

Refs: https://github.com/derailed/k9s/issues/3886