### PR TITLE
Add storage.sh with mc, warp, kubestr, rclone, kopia and weed

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -178,6 +178,17 @@
         "/^kubernetes.sh$/"
       ],
       "matchStrings": [
+        "KRR_VERSION=\\${KRR_VERSION:-v(?<currentValue>.+?)}"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "robusta-dev/krr"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^storage.sh$/"
+      ],
+      "matchStrings": [
         "WARP_VERSION=\\${WARP_VERSION:-v(?<currentValue>.+?)}"
       ],
       "datasourceTemplate": "github-releases",
@@ -186,7 +197,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/^kubernetes.sh$/"
+        "/^storage.sh$/"
       ],
       "matchStrings": [
         "KUBESTR_VERSION=\\${KUBESTR_VERSION:-v?(?<currentValue>[0-9][0-9a-zA-Z.]+)}"
@@ -197,13 +208,35 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/^kubernetes.sh$/"
+        "/^storage.sh$/"
       ],
       "matchStrings": [
-        "KRR_VERSION=\\${KRR_VERSION:-v(?<currentValue>.+?)}"
+        "RCLONE_VERSION=\\${RCLONE_VERSION:-v(?<currentValue>.+?)}"
       ],
       "datasourceTemplate": "github-releases",
-      "depNameTemplate": "robusta-dev/krr"
+      "depNameTemplate": "rclone/rclone"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^storage.sh$/"
+      ],
+      "matchStrings": [
+        "KOPIA_VERSION=\\${KOPIA_VERSION:-v(?<currentValue>.+?)}"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "kopia/kopia"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^storage.sh$/"
+      ],
+      "matchStrings": [
+        "WEED_VERSION=\\${WEED_VERSION:-v?(?<currentValue>[0-9][0-9a-zA-Z.]+)}"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "seaweedfs/seaweedfs"
     },
     {
       "customType": "regex",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,16 @@ jobs:
 
       - name: Test krew override
         run: sudo KREW_VERSION=v0.4.4 bash krew.sh -y
+
+  test-storage:
+    name: Test storage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Test
+        run: sudo bash storage.sh
+
+      - name: Test override
+        run: sudo KUBESTR_VERSION=0.4.48 bash storage.sh

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Kurated Kubernetes tooling installable with one-liner command.
 - [helm](https://github.com/helm/helm)
 - [k9s](https://github.com/derailed/k9s)
 - [kind](https://github.com/kubernetes-sigs/kind/)
+- [kopia](https://github.com/kopia/kopia)
 - [krew](https://krew.sigs.k8s.io/)
 - [krr](https://github.com/robusta-dev/krr)
 - [kubeadm-join-config](https://github.com/mmontes11/k8s-bootstrap/blob/main/cmd/kubeadm-join-config/main.go)
@@ -19,16 +20,19 @@ Kurated Kubernetes tooling installable with one-liner command.
 - [kubectl](https://github.com/kubernetes/kubectl)
 - [kubectx + kubens](https://github.com/ahmetb/kubectx)
 - [kubeseal](https://github.com/bitnami-labs/sealed-secrets)
+- [kubestr](https://github.com/kastenhq/kubestr)
 - [kustomize](https://github.com/kubernetes-sigs/kustomize)
 - [mc](https://github.com/minio/mc)
 - [oc](https://github.com/openshift/oc)
 - [openshift-local](https://developers.redhat.com/products/openshift-local/overview)
 - [operator-sdk](https://github.com/operator-framework/operator-sdk)
 - [opm](https://github.com/operator-framework/operator-registry)
+- [rclone](https://github.com/rclone/rclone)
 - [talosctl](https://github.com/siderolabs/talos/releases)
 - [tekton](https://github.com/tektoncd/cli)
 - [vcluster](https://github.com/loft-sh/vcluster)
 - [warp](https://github.com/minio/warp)
+- [weed (SeaweedFS)](https://github.com/seaweedfs/seaweedfs)
 - [yq](https://github.com/mikefarah/yq)
 
 ### ☸️ Kubernetes
@@ -63,6 +67,16 @@ export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
 ```
 
 [krew](https://krew.sigs.k8s.io/) is also installed by the [Kubernetes](#kubernetes) installation flavour.
+
+### 💾 Storage
+
+```bash
+curl -sfL https://raw.githubusercontent.com/mmontes11/k8s-tooling/main/storage.sh | sudo bash -s -
+```
+
+Installs [mc](https://github.com/minio/mc), [warp](https://github.com/minio/warp), [kubestr](https://github.com/kastenhq/kubestr), [rclone](https://github.com/rclone/rclone), [kopia](https://github.com/kopia/kopia) and [weed](https://github.com/seaweedfs/seaweedfs).
+
+Also installed by the [Kubernetes](#kubernetes) installation flavour.
 
 ### Override versions
 

--- a/kubernetes.sh
+++ b/kubernetes.sh
@@ -107,4 +107,4 @@ source <(curl -s https://raw.githubusercontent.com/mmontes11/k8s-scripts/main/k9
 sudo -u $USER bash -c 'curl -sfL https://raw.githubusercontent.com/mmontes11/k8s-tooling/main/krew.sh | bash'
 
 # # storage
-curl -sfL https://raw.githubusercontent.com/mmontes11/k8s-tooling/main/storage.sh | bash
+# curl -sfL https://raw.githubusercontent.com/mmontes11/k8s-tooling/main/storage.sh | bash

--- a/kubernetes.sh
+++ b/kubernetes.sh
@@ -107,4 +107,4 @@ source <(curl -s https://raw.githubusercontent.com/mmontes11/k8s-scripts/main/k9
 sudo -u $USER bash -c 'curl -sfL https://raw.githubusercontent.com/mmontes11/k8s-tooling/main/krew.sh | bash'
 
 # # storage
-# curl -sfL https://raw.githubusercontent.com/mmontes11/k8s-tooling/main/storage.sh | bash
+curl -sfL https://raw.githubusercontent.com/mmontes11/k8s-tooling/main/storage.sh | bash

--- a/kubernetes.sh
+++ b/kubernetes.sh
@@ -88,20 +88,6 @@ YQ_VERSION=${YQ_VERSION:-v4.53.3}
 YQ_URL=https://github.com/mikefarah/yq/releases/download/$YQ_VERSION/yq_linux_$ARCH
 install_bin yq $YQ_URL
 
-log "Installing MinIO mc..."
-MC_URL=https://dl.min.io/client/mc/release/linux-$ARCH/mc
-install_bin mc $MC_URL
-
-log "Installing MinIO warp..."
-WARP_VERSION=${WARP_VERSION:-v1.5.0}
-WARP_URL=https://dl.min.io/aistor/warp/release/linux-$ARCH/archive/warp.$WARP_VERSION
-install_bin warp $WARP_URL
-
-log "Installing kubestr..."
-KUBESTR_VERSION=${KUBESTR_VERSION:-0.4.49}
-KUBESTR_URL=https://github.com/kastenhq/kubestr/releases/download/v${KUBESTR_VERSION}/kubestr_${KUBESTR_VERSION}_Linux_${ARCH}.tar.gz
-install_tar kubestr $KUBESTR_URL
-
 log "Installing krr..."
 KRR_VERSION=${KRR_VERSION:-v1.28.0}
 KRR_URL="https://github.com/robusta-dev/krr/releases/download/${KRR_VERSION}/krr-ubuntu-latest-${KRR_VERSION}.zip"
@@ -119,3 +105,6 @@ source <(curl -s https://raw.githubusercontent.com/mmontes11/k8s-scripts/main/k9
 
 # # krew
 sudo -u $USER bash -c 'curl -sfL https://raw.githubusercontent.com/mmontes11/k8s-tooling/main/krew.sh | bash'
+
+# # storage
+curl -sfL https://raw.githubusercontent.com/mmontes11/k8s-tooling/main/storage.sh | bash

--- a/storage.sh
+++ b/storage.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -eo pipefail
+
+source <(curl -s source https://raw.githubusercontent.com/mmontes11/k8s-scripts/main/lib.sh)
+
+ARCH=$(get_architecture)
+if [ -z $ARCH ]; then
+  echo "Architecture not supported"
+  exit 1
+fi
+
+log "Installing MinIO mc..."
+MC_URL=https://dl.min.io/client/mc/release/linux-$ARCH/mc
+install_bin mc $MC_URL
+
+log "Installing MinIO warp..."
+WARP_VERSION=${WARP_VERSION:-v1.5.0}
+WARP_URL=https://dl.min.io/aistor/warp/release/linux-$ARCH/archive/warp.$WARP_VERSION
+install_bin warp $WARP_URL
+
+log "Installing kubestr..."
+KUBESTR_VERSION=${KUBESTR_VERSION:-0.4.49}
+KUBESTR_URL=https://github.com/kastenhq/kubestr/releases/download/v${KUBESTR_VERSION}/kubestr_${KUBESTR_VERSION}_Linux_${ARCH}.tar.gz
+install_tar kubestr $KUBESTR_URL
+
+log "Installing rclone..."
+RCLONE_VERSION=${RCLONE_VERSION:-v1.74.3}
+RCLONE_URL=https://github.com/rclone/rclone/releases/download/$RCLONE_VERSION/rclone-$RCLONE_VERSION-linux-$ARCH.zip
+TMP_DIR=$(mktemp -d)
+curl -sSLo "$TMP_DIR/rclone.zip" "$RCLONE_URL"
+unzip -q "$TMP_DIR/rclone.zip" -d "$TMP_DIR"
+chmod +x "$TMP_DIR/rclone-$RCLONE_VERSION-linux-$ARCH/rclone"
+mv "$TMP_DIR/rclone-$RCLONE_VERSION-linux-$ARCH/rclone" /usr/local/bin/rclone
+rm -rf "$TMP_DIR"
+
+log "Installing kopia..."
+KOPIA_VERSION=${KOPIA_VERSION:-v0.23.1}
+KOPIA_ARCH=$ARCH
+if [ "$ARCH" = "amd64" ]; then
+  KOPIA_ARCH=x64
+fi
+KOPIA_URL=https://github.com/kopia/kopia/releases/download/$KOPIA_VERSION/kopia-${KOPIA_VERSION#v}-linux-$KOPIA_ARCH.tar.gz
+install_tar kopia $KOPIA_URL kopia-${KOPIA_VERSION#v}-linux-$KOPIA_ARCH
+
+log "Installing SeaweedFS weed..."
+WEED_VERSION=${WEED_VERSION:-4.37}
+WEED_URL=https://github.com/seaweedfs/seaweedfs/releases/download/$WEED_VERSION/linux_$ARCH.tar.gz
+install_tar weed $WEED_URL
+
+log "Done!"


### PR DESCRIPTION
## Summary
- Adds `storage.sh`, moving `mc`, `warp` and `kubestr` out of `kubernetes.sh` and adding `rclone` (v1.74.3), `kopia` (v0.23.1) and SeaweedFS's `weed` CLI (4.37).
- `kubernetes.sh` now sources `storage.sh` at the end, mirroring how `krew.sh` is sourced.
- Updates `renovate.json` to track the new/moved dependencies in `storage.sh`, and adds a `test-storage` CI job.

## Test plan
- [x] Verified `bash -n` syntax on both scripts
- [x] Verified download/extraction logic for `kubestr`, `kopia`, `weed` and `rclone` against a mocked install dir (each binary ran and printed its version)
- [ ] CI `test-storage` job passes on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)